### PR TITLE
Add note to quickstart about file sync conflicts

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,6 +30,12 @@ Create and Mount Filesystem
 	$ ~/bin/gocryptfs cipher plain
 	  [...]
 
+!!! Note
+
+    If you are intending to syncronize this filesystem across multiple devices by using file syncronization
+    software like Dropbox or Seafile, make sure you use the `-plaintextnames` switch when you initialize it. 
+    This disables file name encryption that would interfere with the conflict handling that these systems use.
+
 You should now have a working gocryptfs that is stored in `cipher` and mounted to `plain`.
 You can verify it by creating a test file in the `plain` directory. This file will show
 up encrypted in the `cipher` directory.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ theme:
     name: readthedocs
     custom_dir: gocryptfs-readthedocs
 plugins: []
+markdown_extensions:
+  - admonition
 pages:
 - Home: index.md
 - Quickstart: quickstart.md


### PR DESCRIPTION
Something I came across recently was how Seafile handles conflict resolution, and how it's not immediately obvious on mounted gocryptfs file systems if a conflict file has been generated. I came across this comment:

https://github.com/rfjakob/gocryptfs/issues/14#issuecomment-168837686

Which suggests enabling -plaintextnames when you initialize the file system if you intend to synchronize it with tools like Dropbox/Seafile. 

I thought it would make sense to add a note to the quickstart section so that users are aware of this at the initialization stage. I'm using the Markdown admonition plugin for the note formatting, so I've enabled it in mkdocs.yml. Here is what it looks like rendered:

![screenshot-2018-2-2 quickstart - gocryptfs](https://user-images.githubusercontent.com/1873618/35717531-daef4af2-0833-11e8-88b7-4af86e8e5ada.png)

I've tried to keep it short so that the quickstart section stays quick, but I was thinking of adding another page/section which explains the problem in more detail (essentially that the conflict files Dropbox or similar tools create are invisible on the mounted file system). I'm sure there are some users who would choose to still use file name encryption and accept the conflict file problem as a trade off.