### PR TITLE
Update and extend encrypted overlay filesystem comparison

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -145,18 +145,20 @@ it seems to describe the used crypto.
 File Contents
 -------------
 
-|                       | gocryptfs |      encfs default      |      encfs paranoia     |        ecryptfs       |      cryptomator       |      securefs      |         CryFS         |
-| --------------------- | --------- | ----------------------- | ----------------------- | --------------------- | ---------------------- | ------------------ | --------------------- |
-| Tested version        | v1.4.1    | v1.9.2                  | v1.9.2                  | v4.12.5               | v1.3.1 RPM             | v0.7.3-30-g2596467 | 0.9.7-15-g3d52f6a8    |
-|                       |           |                         |                         |                       |                        |                    |                       |
-| Encryption            | GCM       | CBC; last block CFB [1] | CBC; last block CFB [1] | CBC                   | CTR with random IV [2] | GCM                | GCM                   |
-| Integrity             | GCM       | none                    | HMAC                    | none                  | HMAC                   | GCM                | GCM                   |
-| File size obfuscation | no        | no                      | no                      | yes (4 KB increments) | no [3]                 | no                 | yes (chunked storage) |
+|                       | gocryptfs |      encfs default      |      encfs paranoia     |        ecryptfs       |      cryptomator       | securefs |         CryFS         |
+| --------------------- | --------- | ----------------------- | ----------------------- | --------------------- | ---------------------- | ---------| --------------------- |
+| Tested version        | v1.7      | v1.9.5                  | v1.9.5                  | v4.19.0               | v1.4.6                 | v0.8.3   | 0.10.0                |
+|                       |           |                         |                         |                       |                        |          |                       |
+| Encryption            | GCM [1]   | CBC; last block CFB [2] | CBC; last block CFB [2] | CBC                   | CTR with random IV [3] | GCM      | GCM                   |
+| Integrity             | GCM       | none                    | HMAC                    | none                  | HMAC                   | GCM      | GCM                   |
+| File size obfuscation | no        | no                      | no                      | yes (4 KB increments) | no [4]                 | no [5]   | yes (chunked storage) |
 
 References:
-[[1]](https://github.com/vgough/encfs/issues/9)
-[[2]](https://github.com/cryptomator/cryptomator/issues/128#issuecomment-168942517)
-[[3]](https://github.com/cryptomator/cryptomator/releases/tag/1.2.0)
+[[1]](https://github.com/rfjakob/gocryptfs/blob/master/Documentation/file-format.md#file-format)
+[[2]](https://github.com/vgough/encfs/issues/9)
+[[3]](https://github.com/cryptomator/cryptomator/issues/128#issuecomment-168942517)
+[[4]](https://github.com/cryptomator/cryptomator/releases/tag/1.2.0)
+[[5]](https://github.com/netheril96/securefs/issues/39)
 
 File Names
 ----------

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -34,12 +34,12 @@ which is why I converted it to html.
 <table>
   <tr>
     <th></th>
-    <th>gocryptfs <br> v1.4.1</th>
-    <th>encfs <br> v1.9.2</th>
-    <th>ecryptfs <br> v4.13</th>
-    <th>cryptomator <br> v1.3.1</th>
-    <th>securefs <br> v0.7.3</th>
-    <th>CryFS <br> v0.9.7</th>
+    <th>gocryptfs <br> v1.7</th>
+    <th>encfs <br> v1.9.5</th>
+    <th>ecryptfs <br> v4.19.0</th>
+    <th>cryptomator <br> v1.4.6</th>
+    <th>securefs <br> v0.8.3</th>
+    <th>CryFS <br> v0.10.0</th>
   </tr>
   <tr>
 	<td>First release</td>
@@ -90,8 +90,8 @@ which is why I converted it to html.
     <td>File interface</td>
 <!-- gocryptfs --><td>FUSE</td>
 <!-- encfs     --><td>FUSE</td>
-<!-- ecryptfs  --><td>in-kernel filesystem</td>
-<!-- cryptomtr --><td>WebDAV</td>
+<!-- ecryptfs  --><td>In-kernel filesystem</td>
+<!-- cryptomtr --><td>FUSE/WebDAV</td>
 <!-- securefs  --><td>FUSE</td>
 <!-- cryfs     --><td>FUSE</td>
   </tr>
@@ -102,21 +102,21 @@ which is why I converted it to html.
 <!-- ecryptfs  --><td>Linux</td>
 <!-- cryptomtr --><td>Linux, MacOS, Windows</td>
 <!-- securefs  --><td>Linux, MacOS, Windows</td>
-<!-- cryfs     --><td>Linux</td>
+<!-- cryfs     --><td>Linux, MacOS, Windows (experimental)</td>
   </tr>
   <tr>
     <td>User interface</td>
-<!-- gocryptfs --><td>CLI, 3rd-party GUI <a href="https://mhogomchungu.github.io/sirikali/">SiriKali</a></td>
+<!-- gocryptfs --><td>CLI, 3rd-party GUI (<a href="https://mhogomchungu.github.io/sirikali/">SiriKali</a>)</td>
 <!-- encfs     --><td>CLI, 3rd-party GUI</td>
 <!-- ecryptfs  --><td>Integrated in login process</td>
 <!-- cryptomtr --><td>GUI, 3rd-party CLI (<a href="https://github.com/cryptomator/cli">ref</a>) </td>
 <!-- securefs  --><td>CLI, 3rd-party GUI</td>
-<!-- cryfs     --><td>CLI, 3rd-party GUI</td>
+<!-- cryfs     --><td>CLI, 3rd-party GUI (<a href="https://mhogomchungu.github.io/sirikali/">SiriKali</a>)</td>
   </tr>
   <tr>
     <td>Reverse Mode</td>
-<!-- gocryptfs --><td>yes (since v1.1)</td>
-<!-- encfs     --><td>yes</td>
+<!-- gocryptfs --><td>yes (since v1.1, read-only)</td>
+<!-- encfs     --><td>yes (limited write support)</td>
 <!-- ecryptfs  --><td>no</td>
 <!-- cryptomtr --><td>no</td>
 <!-- securefs  --><td>no</td>

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -186,8 +186,8 @@ Notes:
 {2} 255 since gocryptfs v0.9, 175 in v0.8 and earlier  
 {3} cryptomator dropped the use of a random padding in v1.2.0 due to performance concerns.  
 
-Performance
------------
+Performance on Linux
+--------------------
 
 All tests are run on tmpfs rule out any influence of the hard disk.
 The CPU is an Intel Pentium G630 with 2 x 2.7GHz that does NOT have AES instructions.
@@ -212,6 +212,41 @@ However, an optimized WebDAV client may be able to significantly speed up small-
 davfs2 is very slow, fusedav does not compile on current Fedora.<br>
 {3} Testing using the built-in WebDAV support in Gnome Files v3.24.2.1, as the write-back
 caching of wdfs makes exact measurements impractical.
+
+Performance on Windows
+----------------------
+
+All tests were run on a Toshiba-RD400 M.2/NVMe SSD rated 2.6 GB/s read and 1.6 GB/s write random-access speed.
+The operating system used was Windows 7 Professional SP1 running on an Intel Core i7-6700 CPU with 4 x 3.40GHz hyperthreaded and AES-NI.
+Tests were run using MSYS-CoreUtils 5.97-3-msys-1.0.13 installed using the MinGW installer. The exact command lines for running the tests are defined in
+[canonical-benchmarks.bash](https://github.com/rfjakob/gocryptfs/blob/f0e29d9b90b63d5fbe4164161ecb0e1035bb4af4/tests/canonical-benchmarks.bash) with minor
+adjustments required to make the test run in this environment.
+
+
+|                          |     (NTFS)      |    cppcryptfs            | EncFSMP default   | EncFS4Win default |    cryptomator    |    securefs   |       CryFS       |
+| ------------------------ | --------------- | ------------------------ | ----------------- | ----------------- | ----------------- | ------------- | ----------------- |
+| Tested version           | v6.1.7601.24382 | v1.4.0.25                | v0.99.1           | v1.10.1-rc14      | v1.4.6            | v0.8.3        | v0.10.0.1201 {1}  |
+| Based on                 | -               | gocryptfs 1.4 compatible | EncFS 1.9.5       | EncFS 1.9.1       | -                 | -             | -                 |
+| Driver                   | (Built-in)      | Dokany 1.2.2.1000        | PFM 1.0.0.192 {2} | Dokany 1.2.2.1000 | Dokany 1.2.2.1000 | WinFSP 2019.1 | Dokany 1.2.2.1000 |
+| User Interface           | -               | GUI                      | GUI<br/>(fails to properly display state) | Tray<br />(very basic) | GUI | No {3} | No {3}    |
+|                          |                 |                          |                   |                   |                   |               |                   |
+| Streaming write          | 2100 MiB/s {4}  | 621 MiB/s                |  58 MiB/s         |  68 MiB/s         |  67 MiB/s         | 289 MiB/s     |  51 MiB/s         |
+| Streaming read           | 3400 MiB/s {4}  | 797 MiB/s                | 251 MiB/s         | 107 MiB/s         | 115 MiB/s         | 542 MiB/s     | 130 MiB/s         |
+| Extract linux-3.0.tar.gz | 26 s            | 456 s                    | 793 s             | 2121 s            | ??? s             | 332 s         | 1124 s            |
+| md5sum linux-3.0         | 51 s            | 364 s                    | 235 s             | 1877 s            | ??? s             | 235 s         | 1254 s            |
+| ls -lR linux-3.0         | 18 s            | 328 s                    | 166 s             | 1269 s            | ??? s             | 183 s         | 1057 s            |
+| Delete linux-3.0         | 18 s            | 432 s                    | (427 s) {5}       | 1666 s            | ??? s             | 260 s         | 1007 s            |
+
+To the extent this was observed at all during the tests, every one of these
+filesystem providers was fully CPU-bound during the small-file tests with
+observed disk access speeds never going beyond 15 MiB/s.
+
+Notes:  
+ {1} CryFS considered Windows support “highly experimental” in this version<br />
+ {2} Closed source component by Pismo Technic Inc<br />
+ {3} SiriKali (third-part GUI) can be used for management however<br />
+ {4} Yes, these numbers are actually above what the drive is theoretically capable of, so all of these results are likely somewhat skewed<br />
+ {5} 320 files were not deleted due to *Invalid argument* errors; it is not clear what caused this error, but the logged “Invalid data size, not multiple of block size” messages may indicate corruption
 
 Disk Space Efficiency
 ---------------------

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -232,10 +232,10 @@ adjustments required to make the test run in this environment.
 |                          |                 |                          |                   |                   |                   |               |                   |
 | Streaming write          | 2100 MiB/s {4}  | 621 MiB/s                |  58 MiB/s         |  68 MiB/s         |  67 MiB/s         | 289 MiB/s     |  51 MiB/s         |
 | Streaming read           | 3400 MiB/s {4}  | 797 MiB/s                | 251 MiB/s         | 107 MiB/s         | 115 MiB/s         | 542 MiB/s     | 130 MiB/s         |
-| Extract linux-3.0.tar.gz | 26 s            | 456 s                    | 793 s             | 2121 s            | ??? s             | 332 s         | 1124 s            |
-| md5sum linux-3.0         | 51 s            | 364 s                    | 235 s             | 1877 s            | ??? s             | 235 s         | 1254 s            |
-| ls -lR linux-3.0         | 18 s            | 328 s                    | 166 s             | 1269 s            | ??? s             | 183 s         | 1057 s            |
-| Delete linux-3.0         | 18 s            | 432 s                    | (427 s) {5}       | 1666 s            | ??? s             | 260 s         | 1007 s            |
+| Extract linux-3.0.tar.gz | 26 s            | 456 s                    | 793 s             | 2121 s            | 2497 s            | 332 s         | 1124 s            |
+| md5sum linux-3.0         | 51 s            | 364 s                    | 235 s             | 1877 s            | 1808 s            | 235 s         | 1254 s            |
+| ls -lR linux-3.0         | 18 s            | 328 s                    | 166 s             | 1269 s            | 1722 s            | 183 s         | 1057 s            |
+| Delete linux-3.0         | 18 s            | 432 s                    | (427 s) {5}       | 1666 s            | 2765 s            | 260 s         | 1007 s            |
 
 To the extent this was observed at all during the tests, every one of these
 filesystem providers was fully CPU-bound during the small-file tests with
@@ -244,7 +244,7 @@ observed disk access speeds never going beyond 15 MiB/s.
 Notes:  
  {1} CryFS considered Windows support “highly experimental” in this version<br />
  {2} Closed source component by Pismo Technic Inc<br />
- {3} SiriKali (third-part GUI) can be used for management however<br />
+ {3} The SiriKali third-part GUI supports CryFS, EncFS4Win and securefs<br />
  {4} Yes, these numbers are actually above what the drive is theoretically capable of, so all of these results are likely somewhat skewed<br />
  {5} 320 files were not deleted due to *Invalid argument* errors; it is not clear what caused this error, but the logged “Invalid data size, not multiple of block size” messages may indicate corruption
 


### PR DESCRIPTION
Hi! I really enjoyed your comparison of encrypted filesystems and since I recently moved somebody (Windows user by necessity) away from EncFSMP because of its unreliability, I was now confronted with a choice between the several systems you listed in your comparison. As such I was really looking for decent Windows data of these systems, which unfortunately doesn't seem to be available anywhere.

While I know that technically your own tool isn't even on the list, I hope you can still accept this data as cross-platform usage of these file systems is an important aspect of their usability and having a decent user-experience everywhere is IMHO part of the deal.

Danke auf jeden Fall für die Arbeit die du in dieses Programm und die Tabelle gesteckt hast! Super nützlich!