### PR TITLE
mention that empty files do not contain a header

### DIFF
--- a/docs/forward_mode_crypto.md
+++ b/docs/forward_mode_crypto.md
@@ -54,7 +54,7 @@ between or within files.
 ![](img/file-content-encryption.svg)
 
 To support sparse files, all-zero blocks are accepted and passed through
-unchanged.
+unchanged. Empty files do not contain a header.
 
 File Names
 ----------


### PR DESCRIPTION
When reimplementing the file creation in Python, I was suprised today that empty files are in fact zero bytes. While gocryptfs could handle opening my 18 byte "empty" files as well, I think thats a cool feature and should be mentioned!

If you think thats useless information for the end-user, feel free to close this PR :) 